### PR TITLE
Fix PHP tags and remove eval from page parsing

### DIFF
--- a/category.php
+++ b/category.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include "data.php";
 
 $category = $_SERVER['QUERY_STRING'];

--- a/functions.php
+++ b/functions.php
@@ -1,17 +1,29 @@
 <?php
-    function config_page($data) {
-
-
-        //Get configuration
- 
-        $var=$data;
-        $configs=preg_split("/<!--/",$var,2);
-        $configs=preg_split("/-->/",$configs[1],2);
-
-        $config=$configs[0];
-        
-
-   
-        return $config;
+function config_page($data)
+{
+    // Extract the first HTML comment block
+    if (!preg_match('/<!--(.*?)-->/s', $data, $matches)) {
+        return [];
     }
+
+    $configBlock = trim($matches[1]);
+    $result = [];
+
+    foreach (preg_split('/\r?\n/', $configBlock) as $line) {
+        $line = trim($line);
+        if (preg_match('/^\$([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+);$/', $line, $m)) {
+            $key = $m[1];
+            $value = trim($m[2]);
+
+            if ((substr($value, 0, 1) === '"' && substr($value, -1) === '"') ||
+                (substr($value, 0, 1) === "'" && substr($value, -1) === "'")) {
+                $value = substr($value, 1, -1);
+            }
+
+            $result[$key] = $value;
+        }
+    }
+
+    return $result;
+}
 ?>

--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include "data.php";
 
 ?>

--- a/page.php
+++ b/page.php
@@ -1,23 +1,27 @@
-<?
+<?php
 include "data.php";
 include "functions.php";
 
 $clear_title = $_GET['clear_title'];
-$file = "./page/".$clear_title.".html";
+$file = "./page/" . $clear_title . ".html";
 
-if(file_exists($file)){
-	$file = file_get_contents($file);
+$page = new stdClass();
 
-	$page_vars = config_page($file);
-	eval(strip_tags($page_vars));
+if (file_exists($file)) {
+    $fileContent = file_get_contents($file);
 
-	$page->title = $title;
-	$page->keywords = $keywords;
-	$page->content = $file;
-		
-	if($login == 'required'){
-		if(!$_SESSION['uid']){ header("Location: /"); };
-	}
+    $pageVars = config_page($fileContent);
+
+    $page->title = $pageVars['title'] ?? '';
+    $page->keywords = $pageVars['keywords'] ?? '';
+    $login = $pageVars['login'] ?? '';
+    $page->content = $fileContent;
+
+    if ($login === 'required') {
+        if (!$_SESSION['uid']) {
+            header("Location: /");
+        }
+    }
 }else{
 
 	$cachefile = $_SERVER['SERVER_NAME'].$clear_title;

--- a/product.php
+++ b/product.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include "data.php";
 
 $clear_title = $_GET['clear_title'];


### PR DESCRIPTION
## Summary
- replace short open tags with `<?php` at file start
- parse page configuration without `eval`

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685141a13ce08330bf80e50e7c052e0b