### PR TITLE
Improve PHP theme with offline data and header

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,13 @@
-To make this website works, you need to create an account on Shoppi, open a store and associate your domain.
-Then upload your files in the same domain you declared on the Shoppi's website.
+This project contains a simplified e‑commerce template.
 
-Do you need hosting?
-https://www.shoppi.cloud
+### Local setup
+
+1. Upload the repository to a PHP capable web server.
+2. Ensure the `data` directory is writable so caching works.
+3. If the remote Shoppi API is unreachable the application falls back to the
+   sample data located in `data/local_data.json` and the product lists under the
+   `data` directory.
+
+The original project required a Shoppi account. For demonstration purposes this
+repository now includes example JSON files so the pages can render without an
+external account.

--- a/category.php
+++ b/category.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include "data.php";
 
 $category = $_SERVER['QUERY_STRING'];
@@ -115,7 +115,7 @@ $category = $data->request("https://www.shoppiapp.com/api/website/category/json?
         padding-left: 5px !important;
     }
 </style>
-<? include "header.php"; ?>
+<?php include "header.php"; ?>
 <div class="page-content">
 	<div class="holder breadcrumbs-wrap mt-0">
 		<div class="container">
@@ -4347,5 +4347,5 @@ $category = $data->request("https://www.shoppiapp.com/api/website/category/json?
 <!--</div>-->
 <script src="/js/category.js"></script>
 <script src="/js/cart.js"></script>
-<? include "footer.php"; ?>
-<? include "templates/category/category-product.php"; ?>
+<?php include "footer.php"; ?>
+<?php include "templates/category/category-product.php"; ?>

--- a/css/header.css
+++ b/css/header.css
@@ -1,0 +1,29 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+header {
+    background: #222;
+    color: #fff;
+    padding: 10px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+header .logo img {
+    height: 40px;
+}
+header nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+}
+header nav ul li {
+    margin-right: 15px;
+}
+header nav ul li a {
+    color: #fff;
+    text-decoration: none;
+}

--- a/data.php
+++ b/data.php
@@ -58,17 +58,23 @@ class data{
 			$context = stream_context_create($opts);
 
 	
-			$info = $mem_var->get($prefix);
-			
-			
-			if(!$info){
-				$info = $this->request("https://www.shoppiapp.com/api/website/info/json");
+                        $info = $mem_var->get($prefix);
 
-				$mem_var->set($prefix, $info);
-			}
+                        if(!$info){
+                                $info = $this->request("https://www.shoppiapp.com/api/website/info/json");
+
+                                if(!$info){
+                                        $localFile = __DIR__ . '/data/local_data.json';
+                                        if(file_exists($localFile)){
+                                                $info = json_decode(file_get_contents($localFile));
+                                        }
+                                }
+
+                                $mem_var->set($prefix, $info);
+                        }
 			
 		
-			$array = (array)$info->info;
+                        $array = isset($info->info) ? (array)$info->info : [];
 			
 			foreach($array as $name=>$data){
 				$this->set($name, $data);			

--- a/data/local_data.json
+++ b/data/local_data.json
@@ -1,0 +1,8 @@
+{
+  "info": {
+    "title": "Demo Store",
+    "logo": "/images/logo.png",
+    "cover": "/images/cover.jpg",
+    "email": "demo@example.com"
+  }
+}

--- a/data/products_best.json
+++ b/data/products_best.json
@@ -1,0 +1,22 @@
+{
+  "products": [
+    {
+      "title": "Sample Best 1",
+      "link": "/product.php?clear_title=sample-best-1",
+      "photo": "/images/sample1.jpg",
+      "category": "Category",
+      "price": "10.00",
+      "price_format": "$10.00",
+      "text": "Great choice"
+    },
+    {
+      "title": "Sample Best 2",
+      "link": "/product.php?clear_title=sample-best-2",
+      "photo": "/images/sample2.jpg",
+      "category": "Category",
+      "price": "12.00",
+      "price_format": "$12.00",
+      "text": "Bestseller"
+    }
+  ]
+}

--- a/data/products_new.json
+++ b/data/products_new.json
@@ -1,0 +1,22 @@
+{
+  "products": [
+    {
+      "title": "New Arrival 1",
+      "link": "/product.php?clear_title=new-arrival-1",
+      "photo": "/images/sample3.jpg",
+      "category": "Category",
+      "price": "20.00",
+      "price_format": "$20.00",
+      "text": "Latest"
+    },
+    {
+      "title": "New Arrival 2",
+      "link": "/product.php?clear_title=new-arrival-2",
+      "photo": "/images/sample4.jpg",
+      "category": "Category",
+      "price": "22.00",
+      "price_format": "$22.00",
+      "text": "Hot"
+    }
+  ]
+}

--- a/header.php
+++ b/header.php
@@ -1,0 +1,17 @@
+<?php
+// Simple site header
+?>
+<header>
+    <div class="logo">
+        <a href="/">
+            <img src="<?php echo isset($data->logo) ? $data->logo : '/images/logo.png'; ?>" alt="<?php echo isset($data->title) ? $data->title : 'Store'; ?>">
+        </a>
+    </div>
+    <nav>
+        <ul>
+            <li><a href="/">Home</a></li>
+            <li><a href="/page/cart.html">Cart</a></li>
+            <li><a href="/page/contact.html">Contact</a></li>
+        </ul>
+    </nav>
+</header>

--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include "data.php";
 
 ?>
@@ -41,7 +41,7 @@ include "data.php";
     		}
     	</style>
     	
-<? include "header.php"; ?>
+<?php include "header.php"; ?>
 
         <div class="page-content">
             <!-- Main Slider -->
@@ -77,7 +77,7 @@ include "data.php";
                                     </div>
                                 </div>
                             </div>
-						<? } ?>
+                                                <?php } ?>
                         </div>
                         <div class="bnslider-arrows container-fluid">
                             <div></div>
@@ -245,13 +245,13 @@ include "data.php";
 								<img class="lazyload lazypreload" data-src="/fotos/marken/<?=$file;?>" data-sizes="auto" alt="Brand">
 							</div>
 						</li>
-						<? } ?>
+                                                <?php } ?>
 					</ul>
 				</div>
 			</div>
 
         </div>
-<? include"footer.php"; ?>
+<?php include "footer.php"; ?>
 
 		<script id="list-new-products" type="text/x-handlebars-template">
 				<div class="prd prd--style2 prd-labels--max prd-labels-shadow prd-w">

--- a/js/home.js
+++ b/js/home.js
@@ -1,6 +1,6 @@
 
 
-	var context = $.get("https://www.shoppiapp.com/api/website/products/json?limit=8&filter=best",function(data){
+        var context = $.get("https://www.shoppiapp.com/api/website/products/json?limit=8&filter=best",function(data){
 
 	// Retrieve the template data from the HTML (jQuery is used here).
 	var template = $('#list-products').html();
@@ -15,11 +15,20 @@
 			// Insert the HTML code into the page
 			$('#products-best-sellers').append(html);	
 		});
-	},'json');
+        },'json').fail(function(){
+            $.get('/data/products_best.json', function(data){
+                var template = $('#list-products').html();
+                $.each(data.products, function(i){
+                    var templateScript = Handlebars.compile(template);
+                    var html = templateScript(data.products[i]);
+                    $('#products-best-sellers').append(html);
+                });
+            },'json');
+        });
 	
 
 
-	var context = $.get("https://www.shoppiapp.com/api/website/products/json?limit=8&filter=new",function(data){
+        var context = $.get("https://www.shoppiapp.com/api/website/products/json?limit=8&filter=new",function(data){
 
 	// Retrieve the template data from the HTML (jQuery is used here).
 	var template = $('#list-new-products').html();
@@ -34,6 +43,15 @@
 			// Insert the HTML code into the page
 			$('#products-new-arrivals').append(html);	
 		});
-	},'json');
+        },'json').fail(function(){
+            $.get('/data/products_new.json', function(data){
+                var template = $('#list-new-products').html();
+                $.each(data.products, function(i){
+                    var templateScript = Handlebars.compile(template);
+                    var html = templateScript(data.products[i]);
+                    $('#products-new-arrivals').append(html);
+                });
+            },'json');
+        });
 
 

--- a/page.php
+++ b/page.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include "data.php";
 include "functions.php";
 
@@ -73,7 +73,7 @@ if(file_exists($file)){
 			    padding-left: 5px !important;
     		}
     	</style>
- 		<? include "header.php"; ?>
+                <?php include "header.php"; ?>
  		
  		   	
          <div class="page-content">
@@ -84,4 +84,4 @@ if(file_exists($file)){
 		?>
 		</div>
 </div>
-<? include"footer.php"; ?>
+<?php include "footer.php"; ?>

--- a/product.php
+++ b/product.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include "data.php";
 
 $clear_title = $_GET['clear_title'];
@@ -59,7 +59,7 @@ if(!$product=$mem_var->get($clear_title)){
 			    padding-left: 5px !important;
     		}
     	</style>
- 		<? include "header.php"; ?>
+                <?php include "header.php"; ?>
  		
  		   	
 <div class="page-content">
@@ -228,4 +228,4 @@ if(!$product=$mem_var->get($clear_title)){
         </div>
 	    <script src="/js/cart.js"></script>   
 	    	
-<? include"footer.php"; ?>
+<?php include "footer.php"; ?>


### PR DESCRIPTION
## Summary
- add minimal header template and stylesheet
- implement fallback in `data.php` when Shoppi API fails
- load local product lists if API calls fail
- switch to full `<?php` tags and fix open PHP
- update README with local setup instructions

## Testing
- `php -l data.php`
- `php -l index.php`
- `php -l page.php`
- `php -l product.php`
- `php -l category.php`

------
https://chatgpt.com/codex/tasks/task_e_6851510895f483309338fe6e8bcb9a1f