### PR TITLE
Implement cached search plugin

### DIFF
--- a/README
+++ b/README
@@ -25,6 +25,10 @@ This project provides a PHP front‑end that connects to the Shoppi API in order
 
 The application will automatically load language strings based on the `lang` query parameter or the value stored in the session. Checkout is handled through the Stripe API using the key configured in the environment file.
 
+## Search Plugin
+
+Client-side search queries `/plugins/search.php` which proxies the Shoppi API and caches results in Redis. Results are rendered using Handlebars templates in `js/search.js`.
+
 ## Hosting
 
 Need hosting? Visit [shoppi.cloud](https://www.shoppi.cloud).

--- a/js/search.js
+++ b/js/search.js
@@ -1,5 +1,4 @@
 $(document).ready(function() {
-    const shoppiPageId = $('body').data('pageid');
     const params = new URLSearchParams(window.location.search);
     const initialQuery = params.get('q') || '';
     const initialMin = params.get('min') || '';
@@ -13,7 +12,7 @@ $(document).ready(function() {
         const query = $('#search-field').val();
         const min = $('#min-price').val();
         const max = $('#max-price').val();
-        let url = `https://www.shoppiapp.com/api/website/products/json?pageId=${shoppiPageId}&search=${encodeURIComponent(query)}`;
+        let url = `/plugins/search.php?q=${encodeURIComponent(query)}`;
         if (min) {
             url += `&min=${min}`;
         }

--- a/plugins/search.php
+++ b/plugins/search.php
@@ -1,0 +1,39 @@
+<?php
+require '../data.php';
+
+header('Content-Type: application/json');
+
+$q = isset($_GET['q']) ? $_GET['q'] : '';
+$min = isset($_GET['min']) ? $_GET['min'] : '';
+$max = isset($_GET['max']) ? $_GET['max'] : '';
+
+$cacheKey = 'search_' . md5($shoppiPageId . '_' . $data->lang . '_' . $q . '_' . $min . '_' . $max);
+if ($cached = $cache->get($cacheKey)) {
+    echo $cached;
+    return;
+}
+
+$url = "https://www.shoppiapp.com/api/website/products/json?pageId=$shoppiPageId&search=" . urlencode($q);
+if ($min !== '') {
+    $url .= "&min=$min";
+}
+if ($max !== '') {
+    $url .= "&max=$max";
+}
+
+$opts = [
+    'http' => [
+        'method' => 'GET',
+        'header' => "Accept-language: {$data->lang}\r\n" .
+                    "Referer: https://{$_SERVER['SERVER_NAME']}\r\n"
+    ]
+];
+$context = stream_context_create($opts);
+$response = file_get_contents($url, false, $context);
+
+if ($response) {
+    $cache->set($cacheKey, $response, 3600);
+}
+
+echo $response;
+


### PR DESCRIPTION
## Summary
- provide `/plugins/search.php` to query Shoppi API and cache results in Redis
- update `js/search.js` to call the new endpoint
- document the search plugin in the README

## Testing
- `php -l plugins/search.php`
- `node -c js/search.js` *(no output means syntax is ok)*

------
https://chatgpt.com/codex/tasks/task_e_68515f5774e08330b371eb4c9a1d0fc7