### PR TITLE
Add server-side caching for footer sections

### DIFF
--- a/app/controllers/HomeController.php
+++ b/app/controllers/HomeController.php
@@ -19,6 +19,7 @@ class HomeController
 
         View::render('home', [
             'data'        => $data,
+            'sections'    => $data->sections(),
             'shoppiPageId'=> $shoppiPageId,
             'sliderFiles' => $sliderFiles,
             'brands'      => $brandFiles,

--- a/app/controllers/PageController.php
+++ b/app/controllers/PageController.php
@@ -13,6 +13,7 @@ class PageController
         View::render('page', [
             'data'        => $data,
             'page'        => $page,
+            'sections'    => $data->sections(),
             'shoppiPageId'=> $shoppiPageId,
             'year'        => date('Y')
         ]);

--- a/app/controllers/ProductController.php
+++ b/app/controllers/ProductController.php
@@ -25,6 +25,7 @@ class ProductController
             'data'        => $data,
             'product'     => $product,
             'keywords'    => $keywords,
+            'sections'    => $data->sections(),
             'shoppiPageId'=> $shoppiPageId,
             'year'        => date('Y')
         ]);

--- a/app/views/partials/footer.html
+++ b/app/views/partials/footer.html
@@ -80,6 +80,21 @@
                 <div class="col-lg col-xl">
                     <div class="footer-block collapsed-mobile">
                         <div class="title">
+                            <h4>Sections</h4>
+                            <span class="toggle-arrow"><span></span><span></span></span>
+                        </div>
+                        <div class="collapsed-content">
+                            <ul>
+                                [[#sections]]
+                                <li><a href="/page/[[clear_title]].html">[[title]]</a></li>
+                                [[/sections]]
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-lg col-xl">
+                    <div class="footer-block collapsed-mobile">
+                        <div class="title">
                             <h4>Safe payments</h4>
                             <span class="toggle-arrow"><span></span><span></span></span>
                         </div>
@@ -256,11 +271,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-    </li>
-
-</script>
-
 <script id="show-category-mobile" type="text/x-handlebars-template">
     <li>
         <a href="#">{{category}}<span class="arrow"><i class="icon-angle-right"></i></span></a>
@@ -286,6 +296,7 @@
         </ul>
     </li>
 </script>
+
 
 <script type="text/javascript">
     $(document).ready(function () {

--- a/data.php
+++ b/data.php
@@ -80,14 +80,28 @@ class data{
 		
 			$array = (array)$info->info;
 			
-			foreach($array as $name=>$data){
-				$this->set($name, $data);			
-			}
+                       foreach($array as $name=>$data){
+                               $this->set($name, $data);
+                       }
 
-        
-		}
-        
-        
+
+                }
+
+        public function sections() {
+            global $cache, $shoppiPageId;
+            $key = 'sections_' . md5($_SERVER['SERVER_NAME'] . '_' . $shoppiPageId . '_' . $this->lang);
+            $sections = $cache->get($key);
+            if (!$sections) {
+                $sections = $this->request('https://www.shoppiapp.com/api/website/sections/json?pageId=' . $shoppiPageId);
+                if ($sections) {
+                    $cache->set($key, $sections, 3600);
+                }
+            }
+
+            return $sections ? (array)$sections->sections : [];
+        }
+
+
      }
 
 


### PR DESCRIPTION
## Summary
- fetch footer sections via PHP and store them in Redis
- pass cached sections to all page controllers
- render sections server-side in the footer instead of client-side JS

## Testing
- `php -l data.php`
- `php -l app/controllers/HomeController.php`
- `php -l app/controllers/PageController.php`
- `php -l app/controllers/ProductController.php`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851650807f0833083efd61e052b3138