### PR TITLE
Add language dropdown and custom styling

### DIFF
--- a/README
+++ b/README
@@ -25,6 +25,10 @@ This project provides a PHP front‑end that connects to the Shoppi API in order
 
 The application will automatically load language strings based on the `lang` query parameter or the value stored in the session. Checkout is handled through the Stripe API using the key configured in the environment file.
 
+### Localization
+
+Translation files live in `app/lang`. Create additional files using the ISO code as the filename (e.g. `fr.php`) returning an associative array of translation keys. The header uses the keys `home` and `cart` for navigation text.
+
 ## Search Plugin
 
 Client-side search queries `/plugins/search.php` which proxies the Shoppi API and caches results in Redis. Results are rendered using Handlebars templates in `page/js/search.js`.

--- a/app/controllers/HomeController.php
+++ b/app/controllers/HomeController.php
@@ -6,7 +6,7 @@ class HomeController
 {
     public function index(): void
     {
-        global $data, $shoppiPageId;
+        global $data, $shoppiPageId, $translations, $lang;
 
         $sliderPath = './fotos/slider/';
         $sliderFiles = array_values(array_diff(scandir($sliderPath), ['.', '..']));
@@ -22,7 +22,11 @@ class HomeController
             'shoppiPageId'=> $shoppiPageId,
             'sliderFiles' => $sliderFiles,
             'brands'      => $brandFiles,
-            'year'        => date('Y')
+            'year'        => date('Y'),
+            'trans'       => $translations,
+            'selected_en' => $lang === 'en' ? 'selected' : '',
+            'selected_de' => $lang === 'de' ? 'selected' : '',
+            'selected_it' => $lang === 'it' ? 'selected' : ''
         ]);
     }
 }

--- a/app/controllers/PageController.php
+++ b/app/controllers/PageController.php
@@ -6,7 +6,7 @@ class PageController
 {
     public function show(string $clearTitle): void
     {
-        global $data, $shoppiPageId;
+        global $data, $shoppiPageId, $translations, $lang;
 
         $page = $data->request('https://www.shoppiapp.com/api/website/page/json?clear_title=' . $clearTitle);
 
@@ -14,7 +14,11 @@ class PageController
             'data'        => $data,
             'page'        => $page,
             'shoppiPageId'=> $shoppiPageId,
-            'year'        => date('Y')
+            'year'        => date('Y'),
+            'trans'       => $translations,
+            'selected_en' => $lang === 'en' ? 'selected' : '',
+            'selected_de' => $lang === 'de' ? 'selected' : '',
+            'selected_it' => $lang === 'it' ? 'selected' : ''
         ]);
     }
 }

--- a/app/controllers/ProductController.php
+++ b/app/controllers/ProductController.php
@@ -6,7 +6,7 @@ class ProductController
 {
     public function show(string $clearTitle): void
     {
-        global $cache, $data, $shoppiPageId;
+        global $cache, $data, $shoppiPageId, $translations, $lang;
 
         if (!$product = $cache->get($clearTitle)) {
             $product = $data->request('https://www.shoppiapp.com/api/website/product/json?clear_title=' . $clearTitle);
@@ -26,7 +26,11 @@ class ProductController
             'product'     => $product,
             'keywords'    => $keywords,
             'shoppiPageId'=> $shoppiPageId,
-            'year'        => date('Y')
+            'year'        => date('Y'),
+            'trans'       => $translations,
+            'selected_en' => $lang === 'en' ? 'selected' : '',
+            'selected_de' => $lang === 'de' ? 'selected' : '',
+            'selected_it' => $lang === 'it' ? 'selected' : ''
         ]);
     }
 }

--- a/app/core/Lang.php
+++ b/app/core/Lang.php
@@ -1,0 +1,8 @@
+<?php
+function loadTranslations(string $lang): array {
+    $file = __DIR__ . '/../lang/' . $lang . '.php';
+    if (file_exists($file)) {
+        return include $file;
+    }
+    return include __DIR__ . '/../lang/en.php';
+}

--- a/app/lang/de.php
+++ b/app/lang/de.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    'home' => 'Startseite',
+    'cart' => 'Warenkorb',
+    'english' => 'Englisch',
+    'german' => 'Deutsch',
+    'italian' => 'Italienisch'
+];

--- a/app/lang/en.php
+++ b/app/lang/en.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    'home' => 'Home',
+    'cart' => 'Cart',
+    'english' => 'English',
+    'german' => 'Deutsch',
+    'italian' => 'Italiano'
+];

--- a/app/lang/it.php
+++ b/app/lang/it.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    'home' => 'Home',
+    'cart' => 'Carrello',
+    'english' => 'Inglese',
+    'german' => 'Tedesco',
+    'italian' => 'Italiano'
+];

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -14,6 +14,7 @@
         <!-- Custom styles for this template -->
         <link href="css/style.css" rel="stylesheet">
         <link href="css/search.css" rel="stylesheet">
+        <link href="css/custom.css" rel="stylesheet">
         <!-- Custom font -->
         <link href="fonts/icomoon/icons.css" rel="stylesheet">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
@@ -184,11 +185,11 @@
             <div class="holder">
                 <div class="container">
                     <div class="title-wrap text-center">
-                        <h2 class="h1-style">Best Seller</h2>
+                        <h2 class="h1-style">New Arrivals</h2>
                     </div>
                     <div class="prd-grid-wrap position-relative">
-                        <div id="products-best-sellers" class="prd-grid data-to-show-4 data-to-show-lg-4 data-to-show-md-3 data-to-show-sm-2 data-to-show-xs-2 js-category-grid" data-grid-tab-content>
-                        </div>
+                        <div id="products-new-arrivals" class="prd-grid data-to-show-4 data-to-show-lg-4 data-to-show-md-3 data-to-show-sm-2 data-to-show-xs-2 js-category-grid" data-grid-tab-content>
+                                                </div>
                     </div>
                 </div>
             </div>
@@ -196,11 +197,11 @@
             <div class="holder">
                 <div class="container">
                     <div class="title-wrap text-center">
-                        <h2 class="h1-style">New Arrivals</h2>
+                        <h2 class="h1-style">Best Seller</h2>
                     </div>
                     <div class="prd-grid-wrap position-relative">
-                        <div id="products-new-arrivals" class="prd-grid data-to-show-4 data-to-show-lg-4 data-to-show-md-3 data-to-show-sm-2 data-to-show-xs-2 js-category-grid" data-grid-tab-content>
-						</div>
+                        <div id="products-best-sellers" class="prd-grid data-to-show-4 data-to-show-lg-4 data-to-show-md-3 data-to-show-sm-2 data-to-show-xs-2 js-category-grid" data-grid-tab-content>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/app/views/page.html
+++ b/app/views/page.html
@@ -14,6 +14,7 @@
         <link href="css/vendor/vendor.min.css" rel="stylesheet">
         <!-- Custom styles for this template -->
         <link href="css/style.css" rel="stylesheet">
+        <link href="css/custom.css" rel="stylesheet">
         <!-- Custom font -->
         <link href="fonts/icomoon/icons.css" rel="stylesheet">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/app/views/partials/header.html
+++ b/app/views/partials/header.html
@@ -1,10 +1,21 @@
 <header class="site-header">
     <nav>
-        <a href="/">Home</a>
-        <a href="/page/cart.html">Cart</a>
+        <a href="/">[[trans.home]]</a>
+        <a href="/page/cart.html">[[trans.cart]]</a>
         <div class="lang-switcher">
-            <a href="?lang=en">EN</a> |
-            <a href="?lang=it">IT</a>
+            <select id="langSelect">
+                <option value="en" [[selected_en]]>[[trans.english]]</option>
+                <option value="de" [[selected_de]]>[[trans.german]]</option>
+                <option value="it" [[selected_it]]>[[trans.italian]]</option>
+            </select>
         </div>
     </nav>
 </header>
+<script>
+document.getElementById('langSelect').addEventListener('change', function () {
+    var lang = this.value;
+    var url = new URL(window.location.href);
+    url.searchParams.set('lang', lang);
+    window.location.href = url.toString();
+});
+</script>

--- a/app/views/product.html
+++ b/app/views/product.html
@@ -17,6 +17,7 @@
         <link href="/css/vendor/vendor.min.css" rel="stylesheet">
         <!-- Custom styles for this template -->
         <link href="/css/style.css" rel="stylesheet">
+        <link href="/css/custom.css" rel="stylesheet">
         <link href="/css/search.css" rel="stylesheet">       
         <!-- Custom font -->
         <link href="/fonts/icomoon/icons.css" rel="stylesheet">

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,12 @@
+.site-header {
+    background-color: #222;
+    padding: 10px;
+}
+.site-header nav a {
+    color: #fff;
+    margin-right: 15px;
+    text-decoration: none;
+}
+.lang-switcher select {
+    padding: 4px;
+}

--- a/data.php
+++ b/data.php
@@ -3,8 +3,12 @@ require_once __DIR__ . '/config.php';
 //include "database.php";
 session_start();
 
+require_once __DIR__ . '/app/core/Lang.php';
+
 $lang = isset($_GET['lang']) ? $_GET['lang'] : ($_SESSION['lang'] ?? envVar('APP_LANG', 'en'));
 $_SESSION['lang'] = $lang;
+
+$translations = loadTranslations($lang);
 
 $cache = getRedisClient();
 


### PR DESCRIPTION
## Summary
- load translations based on selected language
- add `Lang.php` helper and translation files
- include dropdown language selector in header
- reorder home page sections and include custom styles
- document how to localize

## Testing
- `php -l app/core/Lang.php`
- `php -l app/controllers/HomeController.php`
- `php -l app/controllers/PageController.php`
- `php -l app/controllers/ProductController.php`
- `php -l data.php`


------
https://chatgpt.com/codex/tasks/task_e_685168762df48330ac5116280507989a