### PR TITLE
Improve category caching and menu handling

### DIFF
--- a/app/views/partials/footer.html
+++ b/app/views/partials/footer.html
@@ -326,7 +326,27 @@
             return `/category/${found[0]}/${categoryId}`;
         });
 
-        var context = $.get("https://www.shoppiapp.com/api/website/listCategories/json?pageId=[[shoppiPageId]]&limit=20", function (data) {
+        const CATEGORIES_KEY = 'categories_cache';
+        const CATEGORIES_TIME_KEY = 'categories_cache_time';
+        const CACHE_DURATION = 3 * 60 * 1000; // 3 minutes
+
+        const loadCategories = (cb) => {
+            const cached = window.localStorage.getItem(CATEGORIES_KEY);
+            const cachedTime = window.localStorage.getItem(CATEGORIES_TIME_KEY);
+
+            if (cached && cachedTime && (Date.now() - parseInt(cachedTime, 10) < CACHE_DURATION)) {
+                cb(JSON.parse(cached));
+                return;
+            }
+
+            $.get('https://www.shoppiapp.com/api/website/listCategories/json?pageId=[[shoppiPageId]]&limit=20', function (data) {
+                window.localStorage.setItem(CATEGORIES_KEY, JSON.stringify(data));
+                window.localStorage.setItem(CATEGORIES_TIME_KEY, Date.now().toString());
+                cb(data);
+            }, 'json');
+        };
+
+        loadCategories(function (data) {
 
             /*
              Retrieve the template data from the HTML (jQuery is used here).
@@ -334,7 +354,6 @@
             var template = $('#show-category').html();
 
             allCategories = data.categories;
-            window.localStorage.setItem('categories', JSON.stringify(allCategories));
             const headerCategories = data.categories.slice(0, 6);
 
             const recursive = (parentCategoryLink, categories) => {
@@ -392,7 +411,7 @@
                     "height": $('.nav-wrapper .nav-level-1').outerHeight()
                 });
             });
-        }, 'json');
+        });
 
     });
 

--- a/js/header.js
+++ b/js/header.js
@@ -68,23 +68,23 @@ $(document).ready(function() {
         });
     });
 
-    $('.all-categories-menu-toggle').on('click', function (e) {
-        var $mmenu = $('.mobilemenu');
-        $mmenu.on('click', 'a', function (e) {
-            if ($(e.target).parent('li').find('ul').length) {
-                e.preventDefault();
-                that.defaults.curItem = $(this).parent();
-                that._updateActiveMenu();
-            }
-        });
-        $mmenu.on('click', '.nav-toggle', function () {
-            that._updateActiveMenu('back');
-        });
-        $mmenu.on('click', '.nav-viewall', function (e) {
-            e.stopPropagation();
-            location.href = $(this).attr('href');
-        });
+    const $mmenu = $('.mobilemenu');
+    $mmenu.on('click', 'a', function (e) {
+        if ($(e.target).parent('li').find('ul').length) {
+            e.preventDefault();
+            that.defaults.curItem = $(this).parent();
+            that._updateActiveMenu();
+        }
+    });
+    $mmenu.on('click', '.nav-toggle', function () {
+        that._updateActiveMenu('back');
+    });
+    $mmenu.on('click', '.nav-viewall', function (e) {
+        e.stopPropagation();
+        location.href = $(this).attr('href');
+    });
 
+    $('.all-categories-menu-toggle').on('click', function (e) {
         var $this = $(this);
         $this.toggleClass('open');
 
@@ -99,7 +99,6 @@ $(document).ready(function() {
         $(".mobile-menu").toggleClass('active');
         $(".mobilemenu-toggle").toggleClass('active');
         $("body").toggleClass('slidemenu-open');
-
         $('.nav-wrapper').css({
             "height": $('.nav-wrapper .nav-level-1').outerHeight()
         });


### PR DESCRIPTION
## Summary
- cache category list in localStorage for three minutes
- bind mobile menu events once to avoid repeated handlers

## Testing
- `node --check js/header.js`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68516a1d865c83309c159e1d6eea9768